### PR TITLE
Create directories in HDFS as superuser and switch to correct one

### DIFF
--- a/recipes/wordcount.rb
+++ b/recipes/wordcount.rb
@@ -12,9 +12,10 @@ end
 
 
 hops_hdfs_directory "#{Chef::Config.file_cache_path}/apache.txt" do
-  action :put
+  action :put_as_superuser
   dest "/user/#{node.flink.user}"
   owner node.flink.user
+  group node.flink.group
   mode "775"
 end
 


### PR DESCRIPTION
Create directories in HDFS as superuser, which already belongs to certs group and has the correct permissions to use the certificates